### PR TITLE
TEST(day_10): add go_forward tests

### DIFF
--- a/day_10/task_1/tests/pipe_maze_tests.cpp
+++ b/day_10/task_1/tests/pipe_maze_tests.cpp
@@ -22,7 +22,7 @@ TEST_F(PipeMazeTests, GivenStartingPipe_WhenFindNextNeighbors_ExpectTwoMazePoint
     ASSERT_EQ(foundNeighbors.second, MazePoint(2, 1));
 }
 
-TEST_F(PipeMazeTests, GivenStartingPoint_WhenGoForwardTwoTimesFirstDirection_ExpectReturnAppropriateCoordinates)
+TEST_F(PipeMazeTests, GivenStartingPoint_WhenGoForwardTwoTimesInFirstDirection_ExpectReturnNextTwoCoordinatesFromExpectedDirection)
 {
     const MazePoint starting_pipe(find_starting_point(pipe_maze));
     const auto foundNeighbors = find_next_neighbors(pipe_maze, starting_pipe);
@@ -34,7 +34,7 @@ TEST_F(PipeMazeTests, GivenStartingPoint_WhenGoForwardTwoTimesFirstDirection_Exp
     ASSERT_EQ(current_point_in_first_direction, MazePoint(2, 3));
 }
 
-TEST_F(PipeMazeTests, GivenStartingPoint_WhenGoForwardTwoTimesSecondDirection_ExpectReturnAppropriateCoordinates)
+TEST_F(PipeMazeTests, GivenStartingPoint_WhenGoForwardTwoTimesInSecondDirection_ExpectReturnNextTwoCoordinatesFromExpectedDirection)
 {
     const MazePoint starting_pipe(find_starting_point(pipe_maze));
     const auto foundNeighbors = find_next_neighbors(pipe_maze, starting_pipe);

--- a/day_10/task_1/tests/pipe_maze_tests.cpp
+++ b/day_10/task_1/tests/pipe_maze_tests.cpp
@@ -21,3 +21,28 @@ TEST_F(PipeMazeTests, GivenStartingPipe_WhenFindNextNeighbors_ExpectTwoMazePoint
     ASSERT_EQ(foundNeighbors.first, MazePoint(1, 2));
     ASSERT_EQ(foundNeighbors.second, MazePoint(2, 1));
 }
+
+TEST_F(PipeMazeTests, GivenStartingPoint_WhenGoForwardTwoTimesFirstDirection_ExpectReturnAppropriateCoordinates)
+{
+    const MazePoint starting_pipe(find_starting_point(pipe_maze));
+    const auto foundNeighbors = find_next_neighbors(pipe_maze, starting_pipe);
+
+    auto current_point_in_first_direction = go_forward(foundNeighbors.first, starting_pipe);
+    ASSERT_EQ(current_point_in_first_direction, MazePoint(1, 3));
+    current_point_in_first_direction =
+        go_forward(current_point_in_first_direction, foundNeighbors.first);
+    ASSERT_EQ(current_point_in_first_direction, MazePoint(2, 3));
+}
+
+TEST_F(PipeMazeTests, GivenStartingPoint_WhenGoForwardTwoTimesSecondDirection_ExpectReturnAppropriateCoordinates)
+{
+    const MazePoint starting_pipe(find_starting_point(pipe_maze));
+    const auto foundNeighbors = find_next_neighbors(pipe_maze, starting_pipe);
+
+    auto current_point_in_second_direction =
+        go_forward(foundNeighbors.second, starting_pipe);
+    ASSERT_EQ(current_point_in_second_direction, MazePoint(3, 1));
+    current_point_in_second_direction =
+        go_forward(current_point_in_second_direction, foundNeighbors.second);
+    ASSERT_EQ(current_point_in_second_direction, MazePoint(3, 2));
+}


### PR DESCRIPTION
The goal is to force implementation of function go_forward, which could be used iteratively later to count number of steps to the furthest pipe.

First argument of go_forward is current_pipe.
Second argument is passed as support to let developer to determine the direction of further step.

First scenario basically check, whether we move from '-' to the opposite direction then we came from i.e. here opposite to previous pipe 'S'. go_forward() should give back coordinates of '7' and then following '|' In second scenario it should give back coordinates of 'L' and then following '-'.

Used map:
.....
.S-7.
.|.|.
.L-J.
.....