### PR TITLE
FEAT(Day10): add enclosed_tiles

### DIFF
--- a/day_10/task_2/BUILD
+++ b/day_10/task_2/BUILD
@@ -4,7 +4,6 @@ cc_binary(
     deps = [
         ":pipe_maze",
         "//path_helper"
-        # "//debug_features:debug_features"],
     ]
 )
 

--- a/day_10/task_2/pipe_maze.hpp
+++ b/day_10/task_2/pipe_maze.hpp
@@ -35,6 +35,12 @@ struct AttributedMaze
     void mark_loop_tiles_in_attributed_maze();
     bool is_in_maze(const MazePoint& point) const;
     void color_neighbor(const MazePoint& loop_point, const MazePoint& next_loop_point);
+    int count_enclosed_tiles();
+    void color_neighbors();
+    State find_which_color_is_closed();
+    std::vector<MazePoint> generate_all_surroudning_tiles_starting_from_left_top_clock_wise(const MazePoint& mid_loop_point);
+    void remove_invalid_maze_points(std::vector<MazePoint>& tiles);
+    void print_states();
 
     std::vector<std::vector<AttributedMazePoint>> maze_{};
 };

--- a/day_10/task_2/tests/pipe_maze_tests.cpp
+++ b/day_10/task_2/tests/pipe_maze_tests.cpp
@@ -221,10 +221,9 @@ TEST(AttributedMazeTest, GivenAttributedMazeWithMarkedLoop_WhenCalculateEnclosed
         ".|..|.|..|.",
         ".L--J.L--J.",
         "...........",
-    }
+    };
     AttributedMaze maze(transform_to_attributed_maze(pipe_maze));
     maze.mark_loop_tiles_in_attributed_maze();
-
 
     // When
     const auto result = maze.count_enclosed_tiles();
@@ -232,3 +231,29 @@ TEST(AttributedMazeTest, GivenAttributedMazeWithMarkedLoop_WhenCalculateEnclosed
     // Then
     EXPECT_EQ(result, 4);
 }
+
+TEST(AttributedMazeTest, GivenAttributedMazeWithMarkedLoopButLoopIsCloseToBoundaries_WhenCalculateEnclosedTiles_ThenReturnFour)
+{
+    // Given
+    PipeMaze pipe_maze = {
+        ".F--7F--7",
+        ".|..||..|",
+        ".|F-JL-7|",
+        ".||....||",
+        ".||....||",
+        ".|L----J|",
+        ".S------J",
+    };
+    
+    AttributedMaze maze(transform_to_attributed_maze(pipe_maze));
+    maze.mark_loop_tiles_in_attributed_maze();
+
+    // When
+    const auto result = maze.count_enclosed_tiles();
+
+    // Then
+    EXPECT_EQ(result, 4);
+}
+
+
+


### PR DESCRIPTION
The implementation of the above function forced to add another important function color_neighbors

During implementation few bugs were discovered and fixed in function:
- generate_all_surroudning_tiles_starting_from_left_top_clock_wise problem was with loop tiles bordering the vector boundaries
- find_next_neighbors as above
- is_in_maze - vecotr sizes were swaped

Co-authored-by: Daria Kumanek <dariakumanek@maladie.local>